### PR TITLE
Update 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ az vm list
 # Egyéb parancsok
 
 - [Régió, Előfizetés, Erőforráscsoport](subscription.md)
+- [Tárfiók és fájlmegosztás](storage.md)
 - [Virtuális hálózat](vnet.md)
 - [Virtuálisgép](vm.md)
 - [VMSS](vmss.md)

--- a/storage.md
+++ b/storage.md
@@ -1,0 +1,97 @@
+# Storage parancsok
+
+[![Cloud Shell indítása](https://learn.microsoft.com/azure/cloud-shell/media/embed-cloud-shell/launch-cloud-shell-1.png)](https://shell.azure.com)
+
+## Dokumentáció
+
+- Tárfiók: https://learn.microsoft.com/hu-hu/azure/storage/common/storage-account-overview
+
+## Parancsok
+
+### Tárfiókok listázása
+
+```powershell
+Get-AzStorageAccount
+```
+
+```bash
+az storage account list -o table
+```
+
+### Tárfiók létrehozása
+
+```powershell
+
+
+# Adatok beállítása
+$resourceGroup = "mentorklub2025"
+$location = "Sweden Central"
+
+# Egyedi név generálása kisbetűkkel és számokkal
+$randomName = -join ((97..122) + (48..57) | Get-Random -Count 10 | ForEach-Object {[char]$_})
+$storageAccountName = "tarfiok$randomName"
+
+New-AzStorageAccount -ResourceGroupName $resourceGroup -Name $storageAccountName -Location $location -SkuName Standard_LRS -Kind StorageV2
+```
+
+```bash
+# Adatok beállítása
+resourceGroup="mentorklub2025"
+location="swedencentral"
+
+# Egyedi név generálása kisbetűkkel és számokkal
+storageAccountName="tarfiok$(tr -dc 'a-z0-9' < /dev/urandom | head -c 10)"
+
+az storage account create --name $storageAccountName --resource-group $resourceGroup --location $location --sku Standard_LRS --kind StorageV2
+```
+
+### Blob tároló (container) létrehozása
+
+```powershell
+$containerName = "kepek"
+New-AzStorageContainer -Name $containerName -Context (Get-AzStorageAccount -ResourceGroupName $resourceGroup -Name $storageAccountName).Context
+```
+
+```bash
+containerName="kepek"
+az storage container create --name $containerName --account-name $storageAccountName
+```
+
+### Helyi fájl feltöltése blob tárolóba
+
+```powershell
+Set-AzStorageBlobContent -File ".\kubernetes.webp" -Container $containerName -Blob "kubernetes.webp" -Context (Get-AzStorageAccount -ResourceGroupName $resourceGroup -Name "$storageAccountName").Context
+```
+
+```bash
+az storage blob upload --account-name $storageAccountName --container-name $containerName --name felho.webp --file "./felho.webp"
+```
+
+### Fájlmegosztás létrehozása tárfiókon belül
+
+```powershell
+$shareName = "kmeghajto"
+New-AzStorageShare -Name $shareName -Context (Get-AzStorageAccount -ResourceGroupName $resourceGroup -Name "$storageAccountName").Context
+```
+
+```bash
+az storage share create --name "kmeghajto" --account-name $storageAccountName
+```
+
+### SAS token létrehozása
+
+```powershell
+New-AzStorageBlobSASToken -Container $containerName -Blob "kubernetes.webp" -Permission r -Context (Get-AzStorageAccount -ResourceGroupName $resourceGroup -Name "$storageAccountName").Context -ExpiryTime (Get-Date).AddHours(168)
+
+
+```
+
+```bash
+az storage blob generate-sas \
+    --account-name $storageAccountName \
+    --container-name $containerName \
+    --name "felho.webp" \
+    --permissions r \
+    --expiry $(date -u -d "168 hour" '+%Y-%m-%dT%H:%MZ') \
+    --output tsv
+```

--- a/vm.md
+++ b/vm.md
@@ -4,7 +4,7 @@
 
 ## Dokumentáció
 
-- PowerShell és Azure-Cli: https://learn.microsoft.com/hu-hu/azure/virtual-machines/
+- Virtuális gépek: https://learn.microsoft.com/hu-hu/azure/virtual-machines/
 
 ## Parancsok
 
@@ -25,7 +25,7 @@ az vm list -o table
 - Teljesen önálló VM létrehozása
 
 ```powershell
-$eroforrascsoport='mentorklub'
+$eroforrascsoport='mentorklub2025'
 $regio='Sweden Central'
 $vmneve='WinServer01'
 $vmmerete='Standard_D2s_v3'
@@ -41,7 +41,7 @@ New-AzVm `
     -Name $vmneve `
     -Location $regio `
     -VirtualNetworkName "$vmneve-vnet" `
-    -SubnetName 'frontend' `
+    -SubnetName 'alap' `
     -SecurityGroupName "$vmneve-nsg" `
     -PublicIpAddressName "$vmneve-pip" `
     -Size $vmmerete `
@@ -58,7 +58,7 @@ _Egyéb PowerShell esetén:_
 Linux VM létrehozása, SSH kulcs generálással és saját hálózattal
 
 ```bash
-eroforrascsoport='mentorklub'
+eroforrascsoport='mentorklub2025'
 regio='swedencentral'
 vmneve='LinuxServer01'
 vmmerete='Standard_D2s_v3'
@@ -74,7 +74,7 @@ az vm create \
   --name $vmneve \
   --image Ubuntu2404 \
   --vnet-name "$vmneve-net" \
-  --subnet 'frontend' \
+  --subnet 'alap' \
   --nsg "$vmneve-nsg" \
   --nsg-rule 'SSH' \
   --public-ip-address "$vmneve-pip" \
@@ -87,12 +87,12 @@ az vm create \
 NSG nélküli gépek, létező VNET-be
 
 ```bash
-eroforrascsoport='mentorklub'
+eroforrascsoport='mentorklub2025'
 regio='swedencentral'
 vmneve='LinuxServer02'
 vmmerete='Standard_D2s_v3'
-vnet='mentor-vnet'
-subnet='frontend'
+vnet='mentorklub2025-vnet'
+subnet='alap'
 ```
 
 ```bash
@@ -110,7 +110,8 @@ az vm create \
   --admin-username 'localadmin' \
   --generate-ssh-keys \
   --size $vmmerete \
-  --public-ip-sku Standard
+  --public-ip-sku Standard \
+  --no-wait
 ```
 
 - VM létrehozás saját képfájlból
@@ -118,12 +119,12 @@ az vm create \
 **Linux + Apache2**
 
 ```bash
-eroforrascsoport='mentorklub'
+eroforrascsoport='mentorklub2025'
 regio='swedencentral'
 vmneve='WebServer01'
 vmmerete='Standard_D2s_v3'
-vnet='mentor-vnet'
-subnet='frontend'
+vnet='mentorklub2025-vnet'
+subnet='alap'
 ```
 
 ```bash
@@ -142,18 +143,18 @@ az vm create \
   --size $vmmerete \
   --public-ip-sku Standard \
   --security-type TrustedLaunch \
-  --image "/subscriptions/3a1ff985-e6aa-44a8-ad61-a6827fa6f92a/resourceGroups/mentorklub/providers/Microsoft.Compute/galleries/MentorKlub/images/Ubuntu24-Apache2-TesztOldal/versions/2024.10.15"
+  --image "/subscriptions/3a1ff985-e6aa-44a8-ad61-a6827fa6f92a/resourceGroups/mentorklub-images/providers/Microsoft.Compute/galleries/MentorKlubImages/images/Ubuntu24-Apache2-TesztOldal/versions/2025.02.22"
 ```
 
 **Linux + Webszerver + SQL kapcsolat**
 
 ```bash
-eroforrascsoport='mentorklub'
+eroforrascsoport='mentorklub2025'
 regio='swedencentral'
 vmneve='WebServer02'
 vmmerete='Standard_D2s_v3'
-vnet='mentor-vnet'
-subnet='frontend'
+vnet='mentorklub2025-vnet'
+subnet='alap'
 ```
 
 ```bash
@@ -172,7 +173,7 @@ az vm create \
   --size $vmmerete \
   --public-ip-sku Standard \
   --security-type TrustedLaunch \
-  --image "/subscriptions/3a1ff985-e6aa-44a8-ad61-a6827fa6f92a/resourceGroups/mentorklub/providers/Microsoft.Compute/galleries/MentorKlub/images/Ubuntu24-WebApp-SQL-Kapcsolat/versions/2024.10.15"
+  --image "/subscriptions/3a1ff985-e6aa-44a8-ad61-a6827fa6f92a/resourceGroups/mentorklub-images/providers/Microsoft.Compute/galleries/MentorKlubImages/images/Ubuntu24-WebApp-SQL/versions/2025.02.22"
 ```
 
 _Egyéb Azure-Cli esetén:_

--- a/vmss.md
+++ b/vmss.md
@@ -25,7 +25,7 @@ az vmss list -o table
 
 ```powershell
 # Változók definiálása
-$resourceGroupName = "mentorklub"
+$resourceGroupName = "mentorklub2025"
 $uniqueId = Get-Random
 $scaleSetName = ("$uniqueId" + "-vmss")
 $location = "Sweden Central"
@@ -97,7 +97,7 @@ $vmssConfig = New-AzVmssConfig `
    -Location $location `
    -SkuCapacity 2 `
    -OrchestrationMode Uniform `
-   -SkuName "Standard_B1ls" `
+   -SkuName "Standard_B1s" `
    -UpgradePolicyMode "Automatic" `
    -SecurityType "TrustedLaunch" `
    -Tag @{vmss="$uniqueId"}
@@ -106,7 +106,7 @@ $vmssConfig = New-AzVmssConfig `
 # Saját képfájl hivatkozás
 Set-AzVmssStorageProfile $vmssConfig `
   -OsDiskCreateOption "FromImage" `
-  -ImageReferenceId "/subscriptions/3a1ff985-e6aa-44a8-ad61-a6827fa6f92a/resourceGroups/mentorklub/providers/Microsoft.Compute/galleries/MentorKlub/images/Ubuntu24-Apache2-TesztOldal/versions/2024.10.15" 
+  -ImageReferenceId "/subscriptions/3a1ff985-e6aa-44a8-ad61-a6827fa6f92a/resourceGroups/mentorklub-images/providers/Microsoft.Compute/galleries/MentorKlubImages/images/Ubuntu24-Apache2-TesztOldal/versions/2025.02.22" 
 
 
 
@@ -145,15 +145,15 @@ Get-AzResource -TagValue "vmss egyedi azonosítója a fenti scriptből" | Remove
 
 ```powershell
 # VMSS letárolása
-$vmss = Get-AzVmss -ResourceGroupName "mentorklub" -VMScaleSetName "sajátvmss"
+$vmss = Get-AzVmss -ResourceGroupName "mentorklub2025" -VMScaleSetName "sajátvmss"
 
 # Kívánt VM számosság beállítása
 $vmss.sku.capacity = 3
-Update-AzVmss -ResourceGroupName "mentorklub" -Name "sajátvmss" -VirtualMachineScaleSet $vmss
+Update-AzVmss -ResourceGroupName "mentorklub2025" -Name "sajátvmss" -VirtualMachineScaleSet $vmss
 ```
 
 ```bash
-az vmss scale --name sajátvmss --new-capacity 3 --resource-group mentorklub --verbose
+az vmss scale --name sajátvmss --new-capacity 3 --resource-group mentorklub2025 --verbose
 ```
 
 [<< Vissza](README.md)


### PR DESCRIPTION
This pull request includes updates to several documentation files, focusing on storage commands and virtual machine setups. The main changes involve adding new sections for storage commands, updating resource group names, and modifying VM configurations.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R170): Added a link to the new storage commands section.
* [`storage.md`](diffhunk://#diff-1cd507f05e4d59889106243aa61f4e03aab7a1c230449ca9a66e72b05fd314cfR1-R97): Added detailed instructions and commands for managing storage accounts, containers, and file shares using both PowerShell and Azure CLI.

### Virtual machine configuration updates:

* [`vm.md`](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL28-R28): Updated resource group names from `mentorklub` to `mentorklub2025` in various VM creation examples. [[1]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL28-R28) [[2]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL61-R61) [[3]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL90-R95) [[4]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL113-R127) [[5]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL145-R157) [[6]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL175-R176)
* [`vm.md`](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL44-R44): Changed subnet names from `frontend` to `alap` in VM creation commands. [[1]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL44-R44) [[2]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL77-R77)
* [`vm.md`](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL145-R157): Updated image references to new versions in VM creation commands. [[1]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL145-R157) [[2]](diffhunk://#diff-b17a5aa390a34ec7e6e1da0cb854af6247ef6d7845d5d305d9593c913b1a4e3bL175-R176)

### Virtual machine scale set configuration updates:

* [`vmss.md`](diffhunk://#diff-494db10067c09d182ac90c81c30aa5f5795aeaeda6ebea150d9ce623b9a8196eL28-R28): Updated resource group names from `mentorklub` to `mentorklub2025` in VMSS examples. [[1]](diffhunk://#diff-494db10067c09d182ac90c81c30aa5f5795aeaeda6ebea150d9ce623b9a8196eL28-R28) [[2]](diffhunk://#diff-494db10067c09d182ac90c81c30aa5f5795aeaeda6ebea150d9ce623b9a8196eL148-R156)
* [`vmss.md`](diffhunk://#diff-494db10067c09d182ac90c81c30aa5f5795aeaeda6ebea150d9ce623b9a8196eL100-R100): Changed SKU names and image references to new versions in VMSS configuration commands. [[1]](diffhunk://#diff-494db10067c09d182ac90c81c30aa5f5795aeaeda6ebea150d9ce623b9a8196eL100-R100) [[2]](diffhunk://#diff-494db10067c09d182ac90c81c30aa5f5795aeaeda6ebea150d9ce623b9a8196eL109-R109)